### PR TITLE
[Feature]: 방 생성/게임 종료 UX 개선

### DIFF
--- a/src/entities/room/types/room-detail.ts
+++ b/src/entities/room/types/room-detail.ts
@@ -35,6 +35,8 @@ export interface RoomMeta {
   host: ParticipantProfile;
   countdown: RoomCountdown;
   factionInfos: TeamFaction[];
+  ended?: boolean;
+  endedAt?: string | null;
 }
 
 export interface RoomParticipants {

--- a/src/entities/room/types/room-event.ts
+++ b/src/entities/room/types/room-event.ts
@@ -33,6 +33,22 @@ interface BettingUpdatedEvent {
   };
 }
 
+interface RoomEndingEvent {
+  type: 'room-ending';
+  data: {
+    endsAt: string;
+    endsInSeconds?: number;
+  };
+}
+
+interface RoomEndedEvent {
+  type: 'room-ended';
+  data: {
+    roomId: string;
+    resultPath?: string;
+  };
+}
+
 interface KeepAliveEvent {
   type: 'keep-alive';
 }
@@ -42,4 +58,6 @@ export type RoomServerEvent =
   | EvidenceUpdatedEvent
   | ParticipantUpdatedEvent
   | BettingUpdatedEvent
+  | RoomEndingEvent
+  | RoomEndedEvent
   | KeepAliveEvent;

--- a/src/features/rooms/create/api/create-room.ts
+++ b/src/features/rooms/create/api/create-room.ts
@@ -10,8 +10,6 @@ interface CreateRoomRequest {
   description: string;
   timeLimitMinutes: number;
   minBetPoint: number;
-  visibility: 'public' | 'private';
-  password?: string;
   factions: CreateRoomFactionRequest[];
 }
 

--- a/src/features/rooms/create/model/create-room-form-defaults.ts
+++ b/src/features/rooms/create/model/create-room-form-defaults.ts
@@ -10,8 +10,6 @@ const createRoomFormDefaultValues: CreateRoomFormValues = {
   description: '',
   timeLimitMinutes: '',
   minBetPoint: '',
-  visibility: 'public',
-  password: '',
   factions: [{ ...createRoomFactionDefaultValues }],
 };
 

--- a/src/features/rooms/create/model/create-room-form-schema.test.ts
+++ b/src/features/rooms/create/model/create-room-form-schema.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from 'vitest';
 import {
   CREATE_ROOM_MAX_FACTION_COUNT,
   CREATE_ROOM_MIN_FACTION_COUNT,
-  CREATE_ROOM_PASSWORD_MIN_LENGTH,
   createRoomFormSchema,
 } from './create-room-form-schema';
 
@@ -13,8 +12,6 @@ describe('createRoomFormSchema', () => {
     description: '방 설명입니다.',
     timeLimitMinutes: '30',
     minBetPoint: '100',
-    visibility: 'public' as const,
-    password: '',
     factions: Array.from({ length: CREATE_ROOM_MIN_FACTION_COUNT }, (_, index) => ({
       title: `진영 ${index + 1}`,
       description: '설명',
@@ -33,36 +30,6 @@ describe('createRoomFormSchema', () => {
     if (!result.success) {
       const { fieldErrors } = result.error.flatten();
       expect(fieldErrors.title).toContain('방 제목을 입력해 주세요.');
-    }
-  });
-
-  test('비공개 방인데 비밀번호가 없으면 오류를 반환한다', () => {
-    const result = createRoomFormSchema.safeParse({
-      ...baseInput,
-      visibility: 'private',
-      password: '',
-    });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const { fieldErrors } = result.error.flatten();
-      expect(fieldErrors.password).toContain('비공개 방의 비밀번호를 입력해 주세요.');
-    }
-  });
-
-  test('비밀번호는 최소 길이를 만족해야 한다', () => {
-    const result = createRoomFormSchema.safeParse({
-      ...baseInput,
-      visibility: 'private',
-      password: '123',
-    });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const { fieldErrors } = result.error.flatten();
-      expect(fieldErrors.password).toContain(
-        `비밀번호는 최소 ${CREATE_ROOM_PASSWORD_MIN_LENGTH}자 이상이어야 합니다.`,
-      );
     }
   });
 

--- a/src/features/rooms/create/model/create-room-form-schema.ts
+++ b/src/features/rooms/create/model/create-room-form-schema.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 const CREATE_ROOM_MIN_FACTION_COUNT = 1;
 const CREATE_ROOM_MAX_FACTION_COUNT = 6;
-const CREATE_ROOM_PASSWORD_MIN_LENGTH = 4;
 const CREATE_ROOM_TITLE_MAX_LENGTH = 50;
 const CREATE_ROOM_DESCRIPTION_MAX_LENGTH = 500;
 const CREATE_ROOM_FACTION_TITLE_MAX_LENGTH = 40;
@@ -43,83 +42,51 @@ const createRoomFactionSchema = z.object({
     ),
 });
 
-const createRoomFormSchema = z
-  .object({
-    title: z
-      .string()
-      .trim()
-      .min(1, '방 제목을 입력해 주세요.')
-      .max(
-        CREATE_ROOM_TITLE_MAX_LENGTH,
-        `방 제목은 최대 ${CREATE_ROOM_TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`,
-      ),
-    description: z
-      .string()
-      .trim()
-      .max(
-        CREATE_ROOM_DESCRIPTION_MAX_LENGTH,
-        `방 설명은 최대 ${CREATE_ROOM_DESCRIPTION_MAX_LENGTH}자까지 입력할 수 있습니다.`,
-      ),
-    timeLimitMinutes: numericField({
-      emptyMessage: '제한 시간을 입력해 주세요.',
-      numericMessage: '제한 시간은 숫자만 입력해 주세요.',
-      minMessage: '제한 시간은 1분 이상이어야 합니다.',
-    }),
-    minBetPoint: numericField({
-      emptyMessage: '최소 배팅 포인트를 입력해 주세요.',
-      numericMessage: '최소 배팅 포인트는 숫자만 입력해 주세요.',
-      minMessage: '최소 배팅 포인트는 1 이상이어야 합니다.',
-    }),
-    visibility: z.enum(['public', 'private'], {
-      error: '공개 여부를 선택해 주세요.',
-    }),
-    password: z.string().trim().max(100, '비밀번호는 100자 이하로 입력해 주세요.'),
-    factions: z
-      .array(createRoomFactionSchema)
-      .min(
-        CREATE_ROOM_MIN_FACTION_COUNT,
-        `진영은 최소 ${CREATE_ROOM_MIN_FACTION_COUNT}개 이상이어야 합니다.`,
-      )
-      .max(
-        CREATE_ROOM_MAX_FACTION_COUNT,
-        `진영은 최대 ${CREATE_ROOM_MAX_FACTION_COUNT}개까지 추가할 수 있습니다.`,
-      ),
-  })
-  .superRefine((values, ctx) => {
-    if (values.visibility === 'private') {
-      if (!values.password) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: '비공개 방의 비밀번호를 입력해 주세요.',
-          path: ['password'],
-        });
-      } else if (values.password.length < CREATE_ROOM_PASSWORD_MIN_LENGTH) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `비밀번호는 최소 ${CREATE_ROOM_PASSWORD_MIN_LENGTH}자 이상이어야 합니다.`,
-          path: ['password'],
-        });
-      }
-    }
-
-    if (values.visibility === 'public' && values.password) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: '공개 방에서는 비밀번호를 사용할 수 없습니다.',
-        path: ['password'],
-      });
-    }
-  });
+const createRoomFormSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, '방 제목을 입력해 주세요.')
+    .max(
+      CREATE_ROOM_TITLE_MAX_LENGTH,
+      `방 제목은 최대 ${CREATE_ROOM_TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`,
+    ),
+  description: z
+    .string()
+    .trim()
+    .max(
+      CREATE_ROOM_DESCRIPTION_MAX_LENGTH,
+      `방 설명은 최대 ${CREATE_ROOM_DESCRIPTION_MAX_LENGTH}자까지 입력할 수 있습니다.`,
+    ),
+  timeLimitMinutes: numericField({
+    emptyMessage: '제한 시간을 입력해 주세요.',
+    numericMessage: '제한 시간은 숫자만 입력해 주세요.',
+    minMessage: '제한 시간은 1분 이상이어야 합니다.',
+  }),
+  minBetPoint: numericField({
+    emptyMessage: '최소 배팅 포인트를 입력해 주세요.',
+    numericMessage: '최소 배팅 포인트는 숫자만 입력해 주세요.',
+    minMessage: '최소 배팅 포인트는 1 이상이어야 합니다.',
+  }),
+  factions: z
+    .array(createRoomFactionSchema)
+    .min(
+      CREATE_ROOM_MIN_FACTION_COUNT,
+      `진영은 최소 ${CREATE_ROOM_MIN_FACTION_COUNT}개 이상이어야 합니다.`,
+    )
+    .max(
+      CREATE_ROOM_MAX_FACTION_COUNT,
+      `진영은 최대 ${CREATE_ROOM_MAX_FACTION_COUNT}개까지 추가할 수 있습니다.`,
+    ),
+});
 
 type CreateRoomFactionValues = z.infer<typeof createRoomFactionSchema>;
 type CreateRoomFormValues = z.infer<typeof createRoomFormSchema>;
-type CreateRoomVisibility = CreateRoomFormValues['visibility'];
 
 export {
   CREATE_ROOM_MAX_FACTION_COUNT,
   CREATE_ROOM_MIN_FACTION_COUNT,
-  CREATE_ROOM_PASSWORD_MIN_LENGTH,
   createRoomFactionSchema,
   createRoomFormSchema,
 };
-export type { CreateRoomFactionValues, CreateRoomFormValues, CreateRoomVisibility };
+export type { CreateRoomFactionValues, CreateRoomFormValues };

--- a/src/features/rooms/create/model/use-create-room-form.test.tsx
+++ b/src/features/rooms/create/model/use-create-room-form.test.tsx
@@ -40,23 +40,4 @@ describe('useCreateRoomForm', () => {
 
     expect(result.current.factionFields).toHaveLength(CREATE_ROOM_MIN_FACTION_COUNT);
   });
-
-  test('공개/비공개 전환 시 비밀번호 값을 적절히 초기화한다', () => {
-    const { result } = renderHook(() => useCreateRoomForm());
-
-    act(() => {
-      result.current.setVisibility('private');
-      result.current.form.setValue('password', 'abcd1234', { shouldDirty: true });
-    });
-
-    expect(result.current.isPrivateRoom).toBe(true);
-    expect(result.current.form.getValues('password')).toBe('abcd1234');
-
-    act(() => {
-      result.current.setVisibility('public');
-    });
-
-    expect(result.current.isPrivateRoom).toBe(false);
-    expect(result.current.form.getValues('password')).toBe('');
-  });
 });

--- a/src/features/rooms/create/model/use-create-room-form.ts
+++ b/src/features/rooms/create/model/use-create-room-form.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { type FieldArrayWithId, type UseFormReturn, useFieldArray, useForm } from 'react-hook-form';
 import {
   getCreateRoomFactionDefaultValues,
@@ -11,7 +11,6 @@ import {
   CREATE_ROOM_MAX_FACTION_COUNT,
   CREATE_ROOM_MIN_FACTION_COUNT,
   type CreateRoomFormValues,
-  type CreateRoomVisibility,
   createRoomFormSchema,
 } from './create-room-form-schema';
 
@@ -20,9 +19,7 @@ interface UseCreateRoomFormReturn {
   factionFields: FieldArrayWithId<CreateRoomFormValues, 'factions', 'id'>[];
   appendFaction: () => void;
   removeFaction: (index: number) => void;
-  isPrivateRoom: boolean;
   canAppendFaction: boolean;
-  setVisibility: (visibility: CreateRoomVisibility) => void;
   resetForm: () => void;
 }
 
@@ -40,15 +37,7 @@ function useCreateRoomForm(): UseCreateRoomFormReturn {
     name: 'factions',
   });
 
-  const visibility = form.watch('visibility');
   const factions = form.watch('factions');
-
-  useEffect(() => {
-    if (visibility === 'public' && form.getValues('password')) {
-      form.setValue('password', '', { shouldDirty: true, shouldValidate: true });
-      form.clearErrors('password');
-    }
-  }, [form, visibility]);
 
   const appendFaction = () => {
     const currentCount = form.getValues('factions').length;
@@ -70,19 +59,6 @@ function useCreateRoomForm(): UseCreateRoomFormReturn {
     form.trigger('factions');
   };
 
-  const setVisibility = (nextVisibility: CreateRoomVisibility) => {
-    form.setValue('visibility', nextVisibility, { shouldDirty: true, shouldValidate: true });
-
-    if (nextVisibility === 'private') {
-      return;
-    }
-
-    if (form.getValues('password')) {
-      form.setValue('password', '', { shouldDirty: true, shouldValidate: true });
-      form.clearErrors('password');
-    }
-  };
-
   const resetForm = () => {
     const resetValues = getCreateRoomFormDefaultValues();
     form.reset(resetValues, { keepDefaultValues: false });
@@ -93,9 +69,7 @@ function useCreateRoomForm(): UseCreateRoomFormReturn {
     factionFields: factionArray.fields,
     appendFaction,
     removeFaction,
-    isPrivateRoom: visibility === 'private',
     canAppendFaction: factions.length < CREATE_ROOM_MAX_FACTION_COUNT,
-    setVisibility,
     resetForm,
   };
 }

--- a/src/features/rooms/create/model/use-create-room-mutation.ts
+++ b/src/features/rooms/create/model/use-create-room-mutation.ts
@@ -17,15 +17,11 @@ const CREATE_ROOM_SUCCESS_MESSAGE = '방 생성이 완료되었어요.';
 const CREATE_ROOM_ERROR_MESSAGE = '방 생성에 실패했어요. 잠시 후 다시 시도해 주세요.';
 
 function mapFormValuesToRequest(values: CreateRoomFormValues): CreateRoomRequest {
-  const password = values.visibility === 'private' ? values.password : undefined;
-
   return {
     title: values.title,
     description: values.description,
     timeLimitMinutes: Number(values.timeLimitMinutes),
     minBetPoint: Number(values.minBetPoint),
-    visibility: values.visibility,
-    password,
     factions: values.factions.map((faction) => ({
       title: faction.title,
       description: faction.description,

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -22,6 +22,9 @@ export const ROUTE_PATHS = {
   ROOM(roomId: string): string {
     return `/rooms/${roomId}`;
   },
+  ROOM_RESULT(roomId: string): string {
+    return `/rooms/${roomId}/result`;
+  },
 } as const;
 
 // UI 관련 상수

--- a/src/shared/mocks/handlers/rooms.ts
+++ b/src/shared/mocks/handlers/rooms.ts
@@ -963,7 +963,7 @@ export const roomsHandlers = [
     });
   }),
 
-  http.post('*/rooms/:roomId/end', async ({ params }) => {
+  http.get('*/rooms/:roomId/end', async ({ params }) => {
     const { roomId } = params as { roomId: string };
     const now = Date.now();
     const endsAt = new Date(now + 60 * 1000).toISOString();

--- a/src/shared/mocks/handlers/rooms.ts
+++ b/src/shared/mocks/handlers/rooms.ts
@@ -963,6 +963,32 @@ export const roomsHandlers = [
     });
   }),
 
+  http.post('*/rooms/:roomId/mock-end', async ({ params }) => {
+    const { roomId } = params as { roomId: string };
+    const now = Date.now();
+    const endsAt = new Date(now + 60 * 1000).toISOString();
+
+    broadcastRoomEvent(roomId, {
+      type: 'room-ending',
+      data: {
+        endsAt,
+        endsInSeconds: 60,
+      },
+    });
+
+    setTimeout(() => {
+      broadcastRoomEvent(roomId, {
+        type: 'room-ended',
+        data: {
+          roomId,
+          resultPath: `/rooms/${roomId}/result`,
+        },
+      });
+    }, 500);
+
+    return HttpResponse.json({ message: 'room end simulated' });
+  }),
+
   http.post('*/rooms/:roomId/evidences', async ({ params, request }) => {
     const { roomId } = params as { roomId: string };
     const formData = await request.formData();

--- a/src/shared/mocks/handlers/rooms.ts
+++ b/src/shared/mocks/handlers/rooms.ts
@@ -963,7 +963,7 @@ export const roomsHandlers = [
     });
   }),
 
-  http.post('*/rooms/:roomId/mock-end', async ({ params }) => {
+  http.post('*/rooms/:roomId/end', async ({ params }) => {
     const { roomId } = params as { roomId: string };
     const now = Date.now();
     const endsAt = new Date(now + 60 * 1000).toISOString();

--- a/src/widgets/room-shell/model/use-room-end-flow.test.ts
+++ b/src/widgets/room-shell/model/use-room-end-flow.test.ts
@@ -6,6 +6,8 @@ import { useRoomEndFlow } from './use-room-end-flow';
 
 const replaceMock = vi.fn();
 const handlersRef: { current: RoomEventHandlers | null } = { current: null };
+const toastInfoMock = vi.fn();
+const toastSuccessMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
@@ -20,15 +22,25 @@ vi.mock('@/entities/room/model/use-room-events', () => ({
   },
 }));
 
+vi.mock('sonner', () => ({
+  toast: {
+    info: (...args: unknown[]) => toastInfoMock(...args),
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+  },
+}));
+
 describe('useRoomEndFlow', () => {
   beforeEach(() => {
     handlersRef.current = null;
     replaceMock.mockReset();
   });
 
-  afterEach(() => {});
+  afterEach(() => {
+    toastInfoMock.mockReset();
+    toastSuccessMock.mockReset();
+  });
 
-  test('room-ending 이벤트로 종료 알림 상태를 업데이트한다', () => {
+  test('room-ending 이벤트로 토스트를 띄우고 종료 알림 상태를 업데이트한다', () => {
     const { result } = renderHook(() => useRoomEndFlow('room-1'));
 
     act(() => {
@@ -43,9 +55,10 @@ describe('useRoomEndFlow', () => {
       endsInSeconds: 120,
     });
     expect(result.current.endedInfo).toBeNull();
+    expect(toastInfoMock).toHaveBeenCalled();
   });
 
-  test('room-ended 이벤트로 결과 페이지 이동을 수행한다', () => {
+  test('room-ended 이벤트로 토스트를 띄우고 수동 CTA로만 이동한다', () => {
     const { result } = renderHook(() => useRoomEndFlow('room-1'));
 
     act(() => {
@@ -60,6 +73,8 @@ describe('useRoomEndFlow', () => {
       roomId: 'room-1',
       resultPath: '/rooms/room-1/result',
     });
+    expect(toastSuccessMock).toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
 
     act(() => {
       result.current.handleViewResult();

--- a/src/widgets/room-shell/model/use-room-end-flow.test.ts
+++ b/src/widgets/room-shell/model/use-room-end-flow.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { RoomEventHandlers } from '@/entities/room/model/use-room-events';
+import { useRoomEndFlow } from './use-room-end-flow';
+
+const replaceMock = vi.fn();
+const handlersRef: { current: RoomEventHandlers | null } = { current: null };
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock('@/entities/room/model/use-room-events', () => ({
+  useRoomEvents: (_roomId: string | null, handlers: RoomEventHandlers) => {
+    handlersRef.current = handlers;
+    return { connectionState: 'open', lastError: null };
+  },
+}));
+
+describe('useRoomEndFlow', () => {
+  beforeEach(() => {
+    handlersRef.current = null;
+    replaceMock.mockReset();
+  });
+
+  afterEach(() => {});
+
+  test('room-ending 이벤트로 종료 알림 상태를 업데이트한다', () => {
+    const { result } = renderHook(() => useRoomEndFlow('room-1'));
+
+    act(() => {
+      handlersRef.current?.onRoomEnding?.({
+        endsAt: '2025-12-01T00:00:00.000Z',
+        endsInSeconds: 120,
+      });
+    });
+
+    expect(result.current.endingNotice).toEqual({
+      endsAt: '2025-12-01T00:00:00.000Z',
+      endsInSeconds: 120,
+    });
+    expect(result.current.endedInfo).toBeNull();
+  });
+
+  test('room-ended 이벤트로 결과 페이지 이동을 수행한다', () => {
+    const { result } = renderHook(() => useRoomEndFlow('room-1'));
+
+    act(() => {
+      handlersRef.current?.onRoomEnded?.({
+        roomId: 'room-1',
+        resultPath: '/rooms/room-1/result',
+      });
+    });
+
+    expect(result.current.endingNotice).toBeNull();
+    expect(result.current.endedInfo).toEqual({
+      roomId: 'room-1',
+      resultPath: '/rooms/room-1/result',
+    });
+
+    act(() => {
+      result.current.handleViewResult();
+    });
+    expect(replaceMock).toHaveBeenCalledWith('/rooms/room-1/result');
+  });
+});

--- a/src/widgets/room-shell/model/use-room-end-flow.test.ts
+++ b/src/widgets/room-shell/model/use-room-end-flow.test.ts
@@ -1,7 +1,9 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import type { RoomEventHandlers } from '@/entities/room/model/use-room-events';
+import type { RoomDetail } from '@/entities/room/types/room-detail';
+import { ROUTE_PATHS } from '@/shared/config/constants';
 import { useRoomEndFlow } from './use-room-end-flow';
 
 const replaceMock = vi.fn();
@@ -38,6 +40,19 @@ describe('useRoomEndFlow', () => {
   afterEach(() => {
     toastInfoMock.mockReset();
     toastSuccessMock.mockReset();
+  });
+
+  test('초기 room detail이 종료 상태면 종료 UI를 즉시 노출한다', async () => {
+    const roomDetail = { id: 'room-1', ended: true } as unknown as RoomDetail;
+
+    const { result } = renderHook(() => useRoomEndFlow('room-1', roomDetail));
+
+    await waitFor(() => {
+      expect(result.current.endedInfo).toEqual({
+        roomId: 'room-1',
+        resultPath: ROUTE_PATHS.ROOM_RESULT('room-1'),
+      });
+    });
   });
 
   test('room-ending 이벤트로 토스트를 띄우고 종료 알림 상태를 업데이트한다', () => {

--- a/src/widgets/room-shell/model/use-room-end-flow.ts
+++ b/src/widgets/room-shell/model/use-room-end-flow.ts
@@ -1,0 +1,64 @@
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { useRoomEvents } from '@/entities/room/model/use-room-events';
+import type { RoomServerEvent } from '@/entities/room/types/room-event';
+import { ROUTE_PATHS } from '@/shared/config/constants';
+
+type RoomEndingPayload = Extract<RoomServerEvent, { type: 'room-ending' }>['data'];
+type RoomEndedPayload = Extract<RoomServerEvent, { type: 'room-ended' }>['data'];
+
+function useRoomEndFlow(roomId: string | null) {
+  const router = useRouter();
+  const [endingNotice, setEndingNotice] = useState<RoomEndingPayload | null>(null);
+  const [endedInfo, setEndedInfo] = useState<RoomEndedPayload | null>(null);
+
+  useEffect(() => {
+    // roomId 변화 시 종료 관련 상태를 초기화해 새 방 진입에 대비
+    if (!roomId) {
+      setEndingNotice(null);
+      setEndedInfo(null);
+      return;
+    }
+    setEndingNotice(null);
+    setEndedInfo(null);
+  }, [roomId]);
+
+  const handleRoomEnding = useCallback((data: RoomEndingPayload) => {
+    setEndingNotice(data);
+    toast.info('게임이 곧 종료됩니다.', {
+      description: `종료 예정 시각: ${new Date(data.endsAt).toLocaleString()}`,
+      duration: 5000,
+    });
+  }, []);
+
+  const handleRoomEnded = useCallback((data: RoomEndedPayload) => {
+    setEndedInfo(data);
+    toast.success('게임이 종료되었어요.', {
+      description: '결과를 확인해 주세요.',
+      duration: 5000,
+    });
+  }, []);
+
+  useRoomEvents(roomId, {
+    onRoomEnding: handleRoomEnding,
+    onRoomEnded: handleRoomEnded,
+  });
+
+  const handleViewResult = () => {
+    if (!endedInfo) {
+      return;
+    }
+    const nextPath = endedInfo.resultPath ?? ROUTE_PATHS.ROOM_RESULT(endedInfo.roomId);
+    router.replace(nextPath);
+  };
+
+  return {
+    endingNotice,
+    endedInfo,
+    handleViewResult,
+  };
+}
+
+export { useRoomEndFlow };
+export type { RoomEndingPayload, RoomEndedPayload };

--- a/src/widgets/room-shell/model/use-room-end-flow.ts
+++ b/src/widgets/room-shell/model/use-room-end-flow.ts
@@ -2,13 +2,14 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useRoomEvents } from '@/entities/room/model/use-room-events';
+import type { RoomDetail } from '@/entities/room/types/room-detail';
 import type { RoomServerEvent } from '@/entities/room/types/room-event';
 import { ROUTE_PATHS } from '@/shared/config/constants';
 
 type RoomEndingPayload = Extract<RoomServerEvent, { type: 'room-ending' }>['data'];
 type RoomEndedPayload = Extract<RoomServerEvent, { type: 'room-ended' }>['data'];
 
-function useRoomEndFlow(roomId: string | null) {
+function useRoomEndFlow(roomId: string | null, roomDetail?: RoomDetail | null) {
   const router = useRouter();
   const [endingNotice, setEndingNotice] = useState<RoomEndingPayload | null>(null);
   const [endedInfo, setEndedInfo] = useState<RoomEndedPayload | null>(null);
@@ -23,6 +24,25 @@ function useRoomEndFlow(roomId: string | null) {
     setEndingNotice(null);
     setEndedInfo(null);
   }, [roomId]);
+
+  useEffect(() => {
+    if (!roomId || !roomDetail) {
+      return;
+    }
+
+    const hasEnded = Boolean(roomDetail.endedAt ?? roomDetail.ended);
+    if (!hasEnded) {
+      return;
+    }
+
+    setEndedInfo(
+      (previous) =>
+        previous ?? {
+          roomId: roomDetail.id,
+          resultPath: ROUTE_PATHS.ROOM_RESULT(roomDetail.id),
+        },
+    );
+  }, [roomDetail, roomId]);
 
   const handleRoomEnding = useCallback((data: RoomEndingPayload) => {
     setEndingNotice(data);

--- a/src/widgets/room-shell/ui/room-action-buttons.tsx
+++ b/src/widgets/room-shell/ui/room-action-buttons.tsx
@@ -1,4 +1,4 @@
-import { Coins, FilePlus2 } from 'lucide-react';
+import { Coins, FilePlus2, SquareArrowOutUpRight } from 'lucide-react';
 
 import { Button } from '@/shared/ui/button';
 
@@ -8,6 +8,8 @@ interface RoomActionButtonsProps {
   isEvidenceDisabled?: boolean;
   hasSubmittedEvidence?: boolean;
   isBetDisabled?: boolean;
+  isEnded?: boolean;
+  onResultClick?: () => void;
 }
 
 function RoomActionButtons({
@@ -16,7 +18,25 @@ function RoomActionButtons({
   isEvidenceDisabled,
   hasSubmittedEvidence,
   isBetDisabled,
+  isEnded,
+  onResultClick,
 }: RoomActionButtonsProps) {
+  if (isEnded) {
+    return (
+      <div className="flex flex-row gap-3">
+        <Button
+          className="h-14 w-full rounded-full font-semibold text-base"
+          size="lg"
+          onClick={onResultClick}
+          variant="destructive"
+        >
+          <SquareArrowOutUpRight className="size-5" aria-hidden />
+          <span>결과 확인</span>
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-row gap-3">
       <Button

--- a/src/widgets/room-shell/ui/room-footer-bar.test.tsx
+++ b/src/widgets/room-shell/ui/room-footer-bar.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { RoomFooterBar } from './room-footer-bar';
+
+describe('RoomFooterBar', () => {
+  test('종료된 상태에서는 입력과 제출이 비활성화되고 결과 확인 CTA가 노출된다', () => {
+    const onResultClick = vi.fn();
+    const onSubmit = vi.fn();
+
+    const { container } = render(
+      <RoomFooterBar
+        isEnded
+        onResultClick={onResultClick}
+        onSubmit={onSubmit}
+        onBetClick={vi.fn()}
+        onEvidenceClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('결과 확인')).toBeInTheDocument();
+    const input = screen.getByPlaceholderText('종료된 재판입니다.') as HTMLInputElement;
+    expect(input).toBeDisabled();
+
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    if (form) {
+      fireEvent.submit(form);
+    }
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('결과 확인'));
+    expect(onResultClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/widgets/room-shell/ui/room-footer-bar.tsx
+++ b/src/widgets/room-shell/ui/room-footer-bar.tsx
@@ -15,6 +15,8 @@ interface RoomFooterBarProps {
   hasSubmittedEvidence?: boolean;
   maxLength?: number;
   isBetDisabled?: boolean;
+  isEnded?: boolean;
+  onResultClick?: () => void;
 }
 
 function RoomFooterBar({
@@ -25,6 +27,8 @@ function RoomFooterBar({
   hasSubmittedEvidence,
   maxLength = ROOM_CHAT_CONSTRAINTS.maxLength,
   isBetDisabled,
+  isEnded,
+  onResultClick,
 }: RoomFooterBarProps) {
   const inputId = useId();
   const descriptionId = `${inputId}-description`;
@@ -41,7 +45,7 @@ function RoomFooterBar({
     maxLength,
     onSubmit,
   });
-  const isSubmitDisabled = !value.trim() || Boolean(error);
+  const isSubmitDisabled = isEnded || !value.trim() || Boolean(error);
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-30 px-4 pt-3 pb-[calc(env(safe-area-inset-bottom,0px))]">
@@ -53,11 +57,16 @@ function RoomFooterBar({
             isEvidenceDisabled={isEvidenceDisabled}
             hasSubmittedEvidence={hasSubmittedEvidence}
             isBetDisabled={isBetDisabled}
+            isEnded={isEnded}
+            onResultClick={onResultClick}
           />
           <form
             className="flex w-full gap-3"
             onSubmit={(event) => {
               event.preventDefault();
+              if (isEnded) {
+                return;
+              }
               handleSubmit();
             }}
           >
@@ -68,7 +77,7 @@ function RoomFooterBar({
               id={inputId}
               name="room-chat-input"
               className="flex-1 rounded-full border-2 border-border bg-muted/30 px-6 py-6 text-base"
-              placeholder="채팅을 입력하세요."
+              placeholder={isEnded ? '종료된 재판입니다.' : '채팅을 입력하세요.'}
               value={value}
               onChange={(event) => handleChange(event.target.value)}
               onKeyDown={handleKeyDown}
@@ -76,6 +85,7 @@ function RoomFooterBar({
               onCompositionEnd={handleCompositionEnd}
               aria-describedby={descriptionId}
               aria-invalid={Boolean(error)}
+              disabled={isEnded}
             />
             <Button
               type="submit"
@@ -88,7 +98,7 @@ function RoomFooterBar({
           </form>
           <div className="flex items-center justify-between px-1 text-xs" id={descriptionId}>
             <p className={error ? 'text-destructive' : 'text-muted-foreground'}>
-              {error ?? `남은 글자 수 ${remaining}자`}
+              {isEnded ? '종료된 재판입니다.' : (error ?? `남은 글자 수 ${remaining}자`)}
             </p>
           </div>
         </div>

--- a/src/widgets/room-shell/ui/room-shell.tsx
+++ b/src/widgets/room-shell/ui/room-shell.tsx
@@ -27,7 +27,7 @@ interface RoomShellProps {
 
 function RoomShell({ roomId }: RoomShellProps) {
   const detailQuery = useRoomDetailSnapshot(roomId);
-  const { endedInfo, handleViewResult } = useRoomEndFlow(roomId);
+  const { endedInfo, handleViewResult } = useRoomEndFlow(roomId, detailQuery.data);
   const [isMockingEnd, setIsMockingEnd] = useState(false);
   const isDev = process.env.NODE_ENV !== 'production';
 

--- a/src/widgets/room-shell/ui/room-shell.tsx
+++ b/src/widgets/room-shell/ui/room-shell.tsx
@@ -125,7 +125,7 @@ function RoomShell({ roomId }: RoomShellProps) {
     }
     setIsMockingEnd(true);
     try {
-      await fetch(`/api/rooms/${roomId}/mock-end`, {
+      await fetch(`/api/rooms/${roomId}/end`, {
         method: 'POST',
       });
     } catch (error) {

--- a/src/widgets/room-shell/ui/room-shell.tsx
+++ b/src/widgets/room-shell/ui/room-shell.tsx
@@ -125,9 +125,7 @@ function RoomShell({ roomId }: RoomShellProps) {
     }
     setIsMockingEnd(true);
     try {
-      await fetch(`/api/rooms/${roomId}/end`, {
-        method: 'POST',
-      });
+      await fetch(`/api/rooms/${roomId}/end`);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to trigger mock end event', error);

--- a/src/widgets/room-shell/ui/room-shell.tsx
+++ b/src/widgets/room-shell/ui/room-shell.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { useMemo } from 'react';
+import { CircleSlash } from 'lucide-react';
+import { useMemo, useState } from 'react';
 
 import { ROOM_CHAT_CONSTRAINTS } from '@/entities/room/config/constants';
 import { useRoomDetailSnapshot } from '@/entities/room/model/use-room-detail-snapshot';
-import { useRoomEvents } from '@/entities/room/model/use-room-events';
 import { openBetModal } from '@/features/bet-place/ui/bet-modal';
 import { openEvidenceModal } from '@/features/evidence-submit/ui/evidence-modal';
 import { Button } from '@/shared/ui/button';
 import { useRoomBettingState } from '@/widgets/room-shell/model/use-room-betting-state';
 import { useRoomChatState } from '@/widgets/room-shell/model/use-room-chat-state';
+import { useRoomEndFlow } from '@/widgets/room-shell/model/use-room-end-flow';
 import { useRoomEvidenceState } from '@/widgets/room-shell/model/use-room-evidence-state';
 import { useRoomMetaState } from '@/widgets/room-shell/model/use-room-meta-state';
 import { useRoomParticipantsState } from '@/widgets/room-shell/model/use-room-participants-state';
@@ -26,7 +27,9 @@ interface RoomShellProps {
 
 function RoomShell({ roomId }: RoomShellProps) {
   const detailQuery = useRoomDetailSnapshot(roomId);
-  useRoomEvents(roomId);
+  const { endedInfo, handleViewResult } = useRoomEndFlow(roomId);
+  const [isMockingEnd, setIsMockingEnd] = useState(false);
+  const isDev = process.env.NODE_ENV !== 'production';
 
   const room = detailQuery.data ?? null;
 
@@ -79,7 +82,7 @@ function RoomShell({ roomId }: RoomShellProps) {
   }
 
   const handleOpenBetModal = () => {
-    if (!betting) {
+    if (!betting || isRoomEnded) {
       return;
     }
 
@@ -98,6 +101,9 @@ function RoomShell({ roomId }: RoomShellProps) {
   };
 
   const handleOpenEvidenceModal = () => {
+    if (isRoomEnded) {
+      return;
+    }
     openEvidenceModal({
       roomTitle: roomData.title,
       faction: currentFaction,
@@ -106,9 +112,68 @@ function RoomShell({ roomId }: RoomShellProps) {
     }).catch(() => {});
   };
 
+  const handleChatSubmitSafe = async (value: string) => {
+    if (isRoomEnded) {
+      return;
+    }
+    await handleChatSubmit(value);
+  };
+
+  const handleMockEnd = async () => {
+    if (!roomId) {
+      return;
+    }
+    setIsMockingEnd(true);
+    try {
+      await fetch(`/api/rooms/${roomId}/mock-end`, {
+        method: 'POST',
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to trigger mock end event', error);
+    } finally {
+      setIsMockingEnd(false);
+    }
+  };
+
+  const isRoomEnded = Boolean(endedInfo);
+
   return (
     <div className="relative flex min-h-screen flex-col bg-background pb-40">
+      {isRoomEnded ? (
+        <div className="border-destructive/40 border-b bg-destructive/10 px-4 py-3 text-destructive">
+          <div className="mx-auto flex max-w-6xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <CircleSlash className="h-5 w-5" aria-hidden />
+              <div className="space-y-1">
+                <p className="font-semibold text-sm">이 재판은 종료되었습니다.</p>
+                <p className="text-destructive/90 text-xs">
+                  상호작용은 종료되었으며 결과만 확인할 수 있습니다.
+                </p>
+              </div>
+            </div>
+            <Button variant="destructive" size="sm" onClick={handleViewResult}>
+              결과 확인
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
       <RoomSummaryBar room={roomData} />
+      {isDev ? (
+        <div className="mx-auto flex w-full max-w-6xl justify-end px-4 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleMockEnd}
+            disabled={isMockingEnd}
+            className="text-xs"
+          >
+            {isMockingEnd ? '종료 시뮬레이션 중…' : '종료 이벤트 시뮬레이트'}
+          </Button>
+        </div>
+      ) : null}
 
       <div className="mx-auto w-full max-w-6xl flex-1 px-4 py-6">
         <div className="grid items-start gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
@@ -122,13 +187,15 @@ function RoomShell({ roomId }: RoomShellProps) {
       </div>
 
       <RoomFooterBar
-        onSubmit={handleChatSubmit}
+        onSubmit={handleChatSubmitSafe}
         onBetClick={handleOpenBetModal}
         onEvidenceClick={handleOpenEvidenceModal}
-        isEvidenceDisabled={isEvidenceDisabled}
+        isEvidenceDisabled={isEvidenceDisabled || isRoomEnded}
         hasSubmittedEvidence={hasSubmittedEvidence}
         maxLength={ROOM_CHAT_CONSTRAINTS.maxLength}
-        isBetDisabled={hasPlacedBet}
+        isBetDisabled={hasPlacedBet || isRoomEnded}
+        isEnded={isRoomEnded}
+        onResultClick={handleViewResult}
       />
     </div>
   );

--- a/src/widgets/rooms/create/ui/create-room-panel.test.tsx
+++ b/src/widgets/rooms/create/ui/create-room-panel.test.tsx
@@ -64,7 +64,6 @@ describe('CreateRoomPanel', () => {
     renderWithQueryClient();
 
     expect(screen.getByRole('heading', { name: '기본 정보' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '공개 설정' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '진영 구성' })).toBeInTheDocument();
     expect(screen.getByLabelText(/방 제목/)).toBeInTheDocument();
     expect(screen.getByLabelText(/진영 이름/)).toBeInTheDocument();
@@ -88,46 +87,6 @@ describe('CreateRoomPanel', () => {
 
     expect(screen.getAllByText('진영 이름을 입력해 주세요.')[0]).toBeInTheDocument();
     expect(screen.getAllByText('진영 설명을 입력해 주세요.')[0]).toBeInTheDocument();
-  });
-
-  test('비공개 전환 시 비밀번호 입력이 나타났다가 공개로 돌아오면 숨겨진다', async () => {
-    const user = userEvent.setup();
-    renderWithQueryClient();
-
-    expect(screen.queryByLabelText('방 비밀번호')).not.toBeInTheDocument();
-
-    const [privateRadio] = screen.getAllByRole('radio', { name: /비공개방/ });
-    await user.click(privateRadio);
-    expect(screen.getByLabelText('방 비밀번호')).toBeInTheDocument();
-
-    const [publicRadio] = screen.getAllByRole('radio', { name: /공개방/ });
-    await user.click(publicRadio);
-    expect(screen.queryByLabelText('방 비밀번호')).not.toBeInTheDocument();
-  });
-
-  test('비공개 상태에서 비밀번호 없이 제출하면 오류 메시지를 표시한다', async () => {
-    const user = userEvent.setup();
-    renderWithQueryClient();
-
-    await user.type(screen.getByLabelText(/방 제목/), '비공개 방');
-    await user.type(screen.getByLabelText(/제한 시간/), '45');
-    await user.type(screen.getByLabelText(/최소 배팅 포인트/), '200');
-    await user.type(screen.getByLabelText(/진영 이름/), '진영 A');
-    await user.type(screen.getByLabelText(/진영 설명/), '설명');
-
-    const [privateRadio] = screen.getAllByRole('radio', { name: /비공개방/ });
-    await user.click(privateRadio);
-
-    const submitButton = screen.getByRole('button', { name: '방 생성' });
-    expect(submitButton).toBeDisabled();
-
-    await act(async () => {
-      fireEvent.submit(screen.getByTestId('create-room-form'));
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('비공개 방의 비밀번호를 입력해 주세요.')).toBeInTheDocument();
-    });
   });
 
   test('진영을 추가하고 제거할 수 있다', async () => {

--- a/src/widgets/rooms/create/ui/create-room-panel.tsx
+++ b/src/widgets/rooms/create/ui/create-room-panel.tsx
@@ -21,16 +21,8 @@ import { Input } from '@/shared/ui/input';
 import { Textarea } from '@/shared/ui/textarea';
 
 function CreateRoomPanel() {
-  const {
-    form,
-    factionFields,
-    appendFaction,
-    removeFaction,
-    isPrivateRoom,
-    canAppendFaction,
-    setVisibility,
-    resetForm,
-  } = useCreateRoomForm();
+  const { form, factionFields, appendFaction, removeFaction, canAppendFaction, resetForm } =
+    useCreateRoomForm();
   const { createRoom, isCreatingRoom } = useCreateRoomMutation();
   const isSubmitting = form.formState.isSubmitting || isCreatingRoom;
   const isFormValid = form.formState.isValid;
@@ -161,99 +153,6 @@ function CreateRoomPanel() {
                     )}
                   />
                 </div>
-              </section>
-
-              <section className="space-y-4">
-                <div className="space-y-2">
-                  <h2 className="font-semibold text-lg">공개 설정</h2>
-                  <p className="text-muted-foreground text-sm">
-                    공개 여부를 선택하고 필요 시 비밀번호를 설정하세요.
-                  </p>
-                </div>
-
-                <FormField
-                  control={form.control}
-                  name="visibility"
-                  render={({ field, fieldState }) => (
-                    <FormItem>
-                      <FormLabel className="sr-only">공개 여부</FormLabel>
-                      <FormControl>
-                        <div className="grid gap-3 sm:grid-cols-2">
-                          <label className="flex cursor-pointer gap-3 rounded-2xl border border-border bg-muted/20 p-4 transition focus-within:border-primary hover:border-primary">
-                            <input
-                              ref={field.ref}
-                              name={field.name}
-                              onBlur={field.onBlur}
-                              type="radio"
-                              value="public"
-                              checked={field.value === 'public'}
-                              onChange={() => {
-                                field.onChange('public');
-                                setVisibility('public');
-                              }}
-                              className="mt-1 h-4 w-4 border-primary text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                            />
-                            <span className="space-y-1">
-                              <span className="block font-semibold text-sm">공개방</span>
-                              <span className="block text-muted-foreground text-xs">
-                                누구나 링크로 방에 참여할 수 있습니다.
-                              </span>
-                            </span>
-                          </label>
-                          <label className="flex cursor-pointer gap-3 rounded-2xl border border-border bg-muted/20 p-4 transition focus-within:border-primary hover:border-primary">
-                            <input
-                              ref={field.ref}
-                              name={field.name}
-                              onBlur={field.onBlur}
-                              type="radio"
-                              value="private"
-                              checked={field.value === 'private'}
-                              onChange={() => {
-                                field.onChange('private');
-                                setVisibility('private');
-                              }}
-                              className="mt-1 h-4 w-4 border-primary text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                            />
-                            <span className="space-y-1">
-                              <span className="block font-semibold text-sm">비공개방</span>
-                              <span className="block text-muted-foreground text-xs">
-                                비밀번호를 아는 사용자만 참여할 수 있습니다.
-                              </span>
-                            </span>
-                          </label>
-                        </div>
-                      </FormControl>
-                      {fieldState.error ? (
-                        <FormMessage>{fieldState.error.message}</FormMessage>
-                      ) : null}
-                    </FormItem>
-                  )}
-                />
-
-                {isPrivateRoom ? (
-                  <FormField
-                    control={form.control}
-                    name="password"
-                    render={({ field, fieldState }) => (
-                      <FormItem>
-                        <FormLabel>방 비밀번호</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="password"
-                            placeholder="비밀번호를 입력해 주세요"
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          비공개방 참여자에게만 공유할 비밀번호입니다.
-                        </FormDescription>
-                        {fieldState.error ? (
-                          <FormMessage>{fieldState.error.message}</FormMessage>
-                        ) : null}
-                      </FormItem>
-                    )}
-                  />
-                ) : null}
               </section>
 
               <section className="space-y-4">


### PR DESCRIPTION
#### 🔢 Which issue(s) does this change fix?

closed #27

#### ⚒️ What does this new feature do?

#### 😮 Why is this change necessary?

#### ⁇ How does it address the issue?

#### ⚠️ What side effects does this change have?

#### ✅ Mandatory Checklist

**PRs will only be reviewed after checklist is complete**

- [x] 방 생성 UI에서 비밀방/비밀번호 입력을 제거하고, 생성 payload/타입/validation에서 관련 필드를 삭제한다.
- [x] 방 목록/상세/모킹 데이터에 남아있는 비밀방 표시/필드를 정리한다.
- [x] 게임 종료 예정 알림 UI를 방 내부에 추가하고, 종료 이벤트 시 결과 페이지로 이동할 수 있는 CTA를 제공한다.
- [x] 실시간 이벤트/라우팅 핸들러와 테스트/문서를 업데이트해 새로운 흐름을 반영한다.

By submitting this pull request, I confirm that my contribution is made under the terms of the Lifthus' policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 룸 종료 플로우 추가: 종료 예정 알림(카운트/시간)과 종료 시 결과 확인 흐름 제공
  * 결과 확인 네비게이션 버튼 및 결과 보기 CTA 추가
  * 종료 상태에서 채팅 입력 비활성화 및 베팅/증거 제출 비활성화

* **Chores**
  * 룸 생성 UI에서 공개/비공개 옵션 및 비밀번호 필드 제거

* **Tests**
  * 종료 흐름 및 결과 확인 관련 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->